### PR TITLE
Rewrite functions to optimize memory usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# HEAD
+
+- Added `makeErroredMap` and `makeIdealMap` to generate sky maps observed by a given telescope setup.

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -39,9 +39,9 @@ uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[deps.BenchmarkTools]]
 deps = ["JSON", "Logging", "Printf", "Profile", "Statistics", "UUIDs"]
-git-tree-sha1 = "4c10eee4af024676200bc7752e536f858c6b8f93"
+git-tree-sha1 = "d9a9701b899b30332bbcb3e1679c41cce81fb0e8"
 uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-version = "1.3.1"
+version = "1.3.2"
 
 [[deps.Bzip2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -500,9 +500,9 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[deps.MPI]]
 deps = ["Distributed", "DocStringExtensions", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "Requires", "Serialization", "Sockets"]
-git-tree-sha1 = "a330c3fc517b52723645283a1d18569c58f703dd"
+git-tree-sha1 = "067fd6ff731c8b414b5c1f3de723d8aed3b4198f"
 uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
-version = "0.20.2"
+version = "0.20.3"
 
 [[deps.MPICH_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "Pkg", "TOML"]
@@ -568,9 +568,9 @@ uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 version = "2022.2.1"
 
 [[deps.MuladdMacro]]
-git-tree-sha1 = "c6190f9a7fc5d9d5915ab29f2134421b12d24a68"
+git-tree-sha1 = "cac9cc5499c25554cba55cd3c30543cff5ca4fab"
 uuid = "46d2c3a1-f734-5fdb-9937-b9b9aeba4221"
-version = "0.2.2"
+version = "0.2.4"
 
 [[deps.NaNMath]]
 deps = ["OpenLibm_jll"]
@@ -606,9 +606,9 @@ version = "4.1.3+3"
 
 [[deps.OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "e60321e3f2616584ff98f0a4f18d98ae6f89bbb3"
+git-tree-sha1 = "f6e9dba33f9f2c44e08a020b0caf6903be540004"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "1.1.17+0"
+version = "1.1.19+0"
 
 [[deps.OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
@@ -638,10 +638,10 @@ uuid = "efcefdf7-47ab-520b-bdef-62a2eaa19f15"
 version = "10.40.0+0"
 
 [[deps.Parsers]]
-deps = ["Dates"]
-git-tree-sha1 = "6c01a9b494f6d2a9fc180a08b182fcb06f0958a0"
+deps = ["Dates", "SnoopPrecompile"]
+git-tree-sha1 = "cceb0257b662528ecdf0b4b4302eb00e767b38e7"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.4.2"
+version = "2.5.0"
 
 [[deps.Pipe]]
 git-tree-sha1 = "6842804e7867b115ca9de748a0cf6b364523c16d"
@@ -673,9 +673,9 @@ version = "1.3.1"
 
 [[deps.Plots]]
 deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "JLFzf", "JSON", "LaTeXStrings", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "RelocatableFolders", "Requires", "Scratch", "Showoff", "SnoopPrecompile", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "Unzip"]
-git-tree-sha1 = "0a56829d264eb1bc910cf7c39ac008b5bcb5a0d9"
+git-tree-sha1 = "b434dce10c0290ab22cb941a9d72c470f304c71d"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.35.5"
+version = "1.35.8"
 
 [[deps.Preferences]]
 deps = ["TOML"]
@@ -719,9 +719,9 @@ version = "1.3.1"
 
 [[deps.RecipesPipeline]]
 deps = ["Dates", "NaNMath", "PlotUtils", "RecipesBase", "SnoopPrecompile"]
-git-tree-sha1 = "9b1c0c8e9188950e66fc28f40bfe0f8aac311fe0"
+git-tree-sha1 = "a030182cccc5c461386c6f055c36ab8449ef1340"
 uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
-version = "0.6.7"
+version = "0.6.10"
 
 [[deps.Reexport]]
 git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
@@ -834,7 +834,7 @@ version = "0.3.5"
 
 [[deps.Stripeline]]
 deps = ["AstroLib", "AstroTime", "BenchmarkTools", "CorrNoise", "Dates", "Documenter", "FITSIO", "Healpix", "LinearAlgebra", "MPI", "Printf", "Random", "RandomNumbers", "RecipesBase", "StaticArrays", "Statistics", "Test", "YAML"]
-git-tree-sha1 = "0a6e9509b2f7a487621a44d61f02a345fe8ddb05"
+git-tree-sha1 = "8e2850a0c07d4b23b328e084c22684d84471f668"
 repo-rev = "prm"
 repo-url = "https://github.com/lspestrip/Stripeline.jl"
 uuid = "45029ab0-c194-11e8-0c82-65ed36a31fad"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -126,9 +126,9 @@ uuid = "0374c0b2-85fe-5995-9aba-c71c9668af00"
 version = "1.0.1"
 
 [[deps.DataAPI]]
-git-tree-sha1 = "46d2680e618f8abd007bce0c3026cb0c4a8f2032"
+git-tree-sha1 = "e08915633fcb3ea83bf9d6126292e5bc5c739922"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
-version = "1.12.0"
+version = "1.13.0"
 
 [[deps.DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
@@ -500,9 +500,9 @@ uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[deps.MPI]]
 deps = ["Distributed", "DocStringExtensions", "Libdl", "MPICH_jll", "MPIPreferences", "MPItrampoline_jll", "MicrosoftMPI_jll", "OpenMPI_jll", "Requires", "Serialization", "Sockets"]
-git-tree-sha1 = "067fd6ff731c8b414b5c1f3de723d8aed3b4198f"
+git-tree-sha1 = "649b1c447a6c737d3bec80d0b72ccb7aba82310d"
 uuid = "da04e1cc-30fd-572f-bb4f-1f8673147195"
-version = "0.20.3"
+version = "0.20.4"
 
 [[deps.MPICH_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "MPIPreferences", "Pkg", "TOML"]
@@ -544,9 +544,9 @@ uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 version = "2.28.0+0"
 
 [[deps.Measures]]
-git-tree-sha1 = "e498ddeee6f9fdb4551ce855a46f54dbd900245f"
+git-tree-sha1 = "c13304c81eec1ed3af7fc20e75fb6b26092a1102"
 uuid = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
-version = "0.3.1"
+version = "0.3.2"
 
 [[deps.MicrosoftMPI_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -673,9 +673,9 @@ version = "1.3.1"
 
 [[deps.Plots]]
 deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "JLFzf", "JSON", "LaTeXStrings", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "RelocatableFolders", "Requires", "Scratch", "Showoff", "SnoopPrecompile", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "Unzip"]
-git-tree-sha1 = "b434dce10c0290ab22cb941a9d72c470f304c71d"
+git-tree-sha1 = "47e70b391ff314cc36e7c2400f7d2c5455dc9496"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.35.8"
+version = "1.36.1"
 
 [[deps.Preferences]]
 deps = ["TOML"]
@@ -693,9 +693,9 @@ uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 
 [[deps.Qt5Base_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Fontconfig_jll", "Glib_jll", "JLLWrappers", "Libdl", "Libglvnd_jll", "OpenSSL_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libxcb_jll", "Xorg_xcb_util_image_jll", "Xorg_xcb_util_keysyms_jll", "Xorg_xcb_util_renderutil_jll", "Xorg_xcb_util_wm_jll", "Zlib_jll", "xkbcommon_jll"]
-git-tree-sha1 = "c6c0f690d0cc7caddb74cef7aa847b824a16b256"
+git-tree-sha1 = "0c03844e2231e12fda4d0086fd7cbe4098ee8dc5"
 uuid = "ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
-version = "5.15.3+1"
+version = "5.15.3+2"
 
 [[deps.REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
@@ -785,9 +785,9 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [[deps.SortingAlgorithms]]
 deps = ["DataStructures"]
-git-tree-sha1 = "b3363d7460f7d098ca0912c69b082f75625d7508"
+git-tree-sha1 = "a4ada03f999bd01b3a25dcaa30b2d929fe537e00"
 uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
-version = "1.0.1"
+version = "1.1.0"
 
 [[deps.SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
@@ -834,7 +834,7 @@ version = "0.3.5"
 
 [[deps.Stripeline]]
 deps = ["AstroLib", "AstroTime", "BenchmarkTools", "CorrNoise", "Dates", "Documenter", "FITSIO", "Healpix", "LinearAlgebra", "MPI", "Printf", "Random", "RandomNumbers", "RecipesBase", "StaticArrays", "Statistics", "Test", "YAML"]
-git-tree-sha1 = "8e2850a0c07d4b23b328e084c22684d84471f668"
+git-tree-sha1 = "9bf4b1b496a9ad81f76663bb7c3e1159b9202dbc"
 repo-rev = "prm"
 repo-url = "https://github.com/lspestrip/Stripeline.jl"
 uuid = "45029ab0-c194-11e8-0c82-65ed36a31fad"

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -639,9 +639,9 @@ version = "10.40.0+0"
 
 [[deps.Parsers]]
 deps = ["Dates", "SnoopPrecompile"]
-git-tree-sha1 = "cceb0257b662528ecdf0b4b4302eb00e767b38e7"
+git-tree-sha1 = "b64719e8b4504983c7fca6cc9db3ebc8acc2a4d6"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.5.0"
+version = "2.5.1"
 
 [[deps.Pipe]]
 git-tree-sha1 = "6842804e7867b115ca9de748a0cf6b364523c16d"
@@ -834,7 +834,7 @@ version = "0.3.5"
 
 [[deps.Stripeline]]
 deps = ["AstroLib", "AstroTime", "BenchmarkTools", "CorrNoise", "Dates", "Documenter", "FITSIO", "Healpix", "LinearAlgebra", "MPI", "Printf", "Random", "RandomNumbers", "RecipesBase", "StaticArrays", "Statistics", "Test", "YAML"]
-git-tree-sha1 = "9bf4b1b496a9ad81f76663bb7c3e1159b9202dbc"
+git-tree-sha1 = "10462d1170c4c7c05c3f7482f92cddf610f2b9b2"
 repo-rev = "prm"
 repo-url = "https://github.com/lspestrip/Stripeline.jl"
 uuid = "45029ab0-c194-11e8-0c82-65ed36a31fad"

--- a/src/PRMaps.jl
+++ b/src/PRMaps.jl
@@ -122,14 +122,13 @@ end
 
 function plotErrorMap(
     cam_ang, 
-    telescope_ang, 
-    signal :: HealpixMap, 
+    telescope_ang,
+    signal :: HealpixMap,
+    ideal_map :: HealpixMap, 
     setup :: Setup
     )
     
-    ideal_map = makeIdealMap(cam_ang, signal, setup)
-    errored_map = makeErroredMap(cam_ang, telescope_ang, signal, setup)
-    result_map = ideal_map - errored_map
+    result_map = makeErroredMap(cam_ang, telescope_ang, signal, setup) - ideal_map
 
     map = plot(result_map)
     hist = histogram(result_map[isfinite.(result_map)])

--- a/src/PRMaps.jl
+++ b/src/PRMaps.jl
@@ -17,42 +17,6 @@ function add2pixel!(map, sky_value, pixel_idx, hits_map)
     hits_map.pixels[pixel_idx] += 1
 end
 
-"""
-    getPixelIndex(
-        cam_ang :: Stripeline.CameraAngles,
-        telescope_ang :: Stripeline.TelescopeAngles,
-        signal :: Healpix.HealpixMap,
-        setup :: PRMaps.Setup
-    )
-
-This function return the indeces of the pixel seeing by the telescope given:
-
-    - `cam_ang :: Stripeline.CameraAngles` : encoding the boresight directions of the detector;
-    - `telescope_ang :: Stripeline.TelescopeAngles` :  encoding the non idealities angles of the telescope;
-    - `signal :: Healpix.HealpixMap` : the input map that the telescope is going to observe;
-    - `setup :: PRMaps.Setup` : encoding the information about period of observation and resolution.
-
-"""
-function getPixelIndex(
-    wheelfunction,
-    cam_ang :: Sl.CameraAngles,
-    telescope_ang :: Union{Nothing, Sl.TelescopeAngles},
-    signal :: HealpixMap,
-    setup :: Setup
-    )
-    
-    pixel_index = Array{Int}(undef, length(setup.times))
-    dirs = Array{Float64}(undef, 1, 2)
-    psi = Array{Float64}(undef, 1)
-    
-    for (i, t) in enumerate(setup.times)
-        Sl.genpointings!(wheelfunction, cam_ang, t, dirs, psi; telescope_ang = telescope_ang)
-        pixel_index[i] = ang2pix(signal, dirs[1], dirs[2])
-    end
-
-    pixel_index
-end
-
 function fillMap!(
     wheelfunction,
     map :: HealpixMap,
@@ -82,31 +46,20 @@ function fillMap!(
     end
 end
 
-function fillTOD!(
-    wheelfunction,
-    tod :: Array{Float64},
-    cam_ang :: Sl.CameraAngles,
-    telescope_ang :: Sl.TelescopeAngles,
-    signal :: HealpixMap,
-    setup :: Setup,
+"""
+    makeErroredMap_old(
+        cam_ang :: Sl.CameraAngles, 
+        telescope_angles,
+        signal :: Healpix.HealpixMap,
+        setup :: Setup
     )
 
-    pixbuf = Array{Int}(undef, 4)
-    weightbuf = Array{Float64}(undef, 4)
-    dirs = Array{Float64}(undef, 1, 2)
-    psi = Array{Float64}(undef, 1)
-    
-    for (indx, t) in enumerate(setup.times)
-        
-        Sl.genpointings!(wheelfunction, cam_ang, t, dirs, psi; telescope_ang = telescope_ang)
+Generate a Healpix map using a telescope model that takes into account
+the non idealities to generate the pointing direction. The observed values instead are
+calculated taking into account the ideal pointing directions. 
+The result is a map affected by an error due to the non idealities of the system.
 
-        sky_value = Healpix.interpolate(signal, dirs[1], dirs[2], pixbuf, weightbuf)
-
-        tod[indx] = sky_value
-
-    end
-end
-
+"""
 function makeErroredMap(
     cam_ang :: Sl.CameraAngles,
     telescope_ang :: Sl.TelescopeAngles,
@@ -123,66 +76,6 @@ function makeErroredMap(
     map.pixels = map.pixels ./ hits
     map
 end
-
-
-"""
-    makeErroredMap_old(
-        cam_ang :: Sl.CameraAngles, 
-        telescope_angles,
-        signal :: Healpix.HealpixMap,
-        setup :: Setup
-    )
-
-Generate a Healpix map using a telescope model that takes into account of
-the non idealities to generate the pointing direction. The observed values instead are
-calculated taking into account the ideal pointing directions. The result is a map affected
-by an error due to the non idealities of the system.
-
-"""
-function makeErroredMap_old(
-    cam_ang :: Sl.CameraAngles,
-    telescope_ang :: Sl.TelescopeAngles,
-    signal :: HealpixMap,
-    setup :: Setup   
-)
-    tod = Array{Float64}(undef, length(setup.times))
-
-    wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, setup.τ_s*60.))
-
-    ideal_indx = getPixelIndex(wheelfunction ,cam_ang, nothing, signal, setup)
-
-    fillTOD!(wheelfunction, tod, cam_ang, telescope_ang, signal, setup)
-
-    # Create a map using the values (with error) associated to the pixel that we belive we observe
-    map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
-    map_values = Sl.tod2map_mpi(ideal_indx, tod, 12*(setup.NSIDE^2))
-    map.pixels = map_values
-    
-    map
-
-end
-
-
-#= function makeIdealMap(
-    cam_ang :: Sl.CameraAngles, 
-    telescope_ang :: Nothing,
-    signal :: Healpix.HealpixMap,
-    setup::Setup
-    )
-
-    wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, setup.τ_s*60.))
-
-    pixel_index = getPixelIndex(wheelfunction, cam_ang, telescope_ang, signal, setup)
-
-    sky_tod = signal.pixels[pixel_index]
-
-    map_values = Sl.tod2map_mpi(pixel_index, sky_tod, 12*(setup.NSIDE^2))
-
-    map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
-    map.pixels = map_values
-
-    map
-end =#
 
 function makeIdealMap(
     cam_ang :: Sl.CameraAngles, 
@@ -220,3 +113,94 @@ function makeIdealMap(
 end
 
 end # module PrmMaps
+
+
+
+# --------------------
+# DEPRECATED FUNCTIONS
+# --------------------
+
+#= """
+    getPixelIndex(
+        cam_ang :: Stripeline.CameraAngles,
+        telescope_ang :: Stripeline.TelescopeAngles,
+        signal :: Healpix.HealpixMap,
+        setup :: PRMaps.Setup
+    )
+
+This function return the indeces of the pixel seeing by the telescope given:
+
+    - `cam_ang :: Stripeline.CameraAngles` : encoding the boresight directions of the detector;
+    - `telescope_ang :: Stripeline.TelescopeAngles` :  encoding the non idealities angles of the telescope;
+    - `signal :: Healpix.HealpixMap` : the input map that the telescope is going to observe;
+    - `setup :: PRMaps.Setup` : encoding the information about period of observation and resolution.
+
+"""
+function getPixelIndex(
+    wheelfunction,
+    cam_ang :: Sl.CameraAngles,
+    telescope_ang :: Union{Nothing, Sl.TelescopeAngles},
+    signal :: HealpixMap,
+    setup :: Setup
+    )
+    
+    pixel_index = Array{Int}(undef, length(setup.times))
+    dirs = Array{Float64}(undef, 1, 2)
+    psi = Array{Float64}(undef, 1)
+    
+    for (i, t) in enumerate(setup.times)
+        Sl.genpointings!(wheelfunction, cam_ang, t, dirs, psi; telescope_ang = telescope_ang)
+        pixel_index[i] = ang2pix(signal, dirs[1], dirs[2])
+    end
+
+    pixel_index
+end
+
+function fillTOD!(
+    wheelfunction,
+    tod :: Array{Float64},
+    cam_ang :: Sl.CameraAngles,
+    telescope_ang :: Sl.TelescopeAngles,
+    signal :: HealpixMap,
+    setup :: Setup,
+    )
+
+    pixbuf = Array{Int}(undef, 4)
+    weightbuf = Array{Float64}(undef, 4)
+    dirs = Array{Float64}(undef, 1, 2)
+    psi = Array{Float64}(undef, 1)
+    
+    for (indx, t) in enumerate(setup.times)
+        
+        Sl.genpointings!(wheelfunction, cam_ang, t, dirs, psi; telescope_ang = telescope_ang)
+
+        sky_value = Healpix.interpolate(signal, dirs[1], dirs[2], pixbuf, weightbuf)
+
+        tod[indx] = sky_value
+
+    end
+end
+
+
+function makeErroredMap_old(
+    cam_ang :: Sl.CameraAngles,
+    telescope_ang :: Sl.TelescopeAngles,
+    signal :: HealpixMap,
+    setup :: Setup   
+)
+    tod = Array{Float64}(undef, length(setup.times))
+
+    wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, setup.τ_s*60.))
+
+    ideal_indx = getPixelIndex(wheelfunction ,cam_ang, nothing, signal, setup)
+
+    fillTOD!(wheelfunction, tod, cam_ang, telescope_ang, signal, setup)
+
+    # Create a map using the values (with error) associated to the pixel that we belive we observe
+    map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
+    map_values = Sl.tod2map_mpi(ideal_indx, tod, 12*(setup.NSIDE^2))
+    map.pixels = map_values
+    
+    map
+
+end =#

--- a/src/PRMaps.jl
+++ b/src/PRMaps.jl
@@ -47,7 +47,7 @@ function fillMap!(
 end
 
 """
-    makeErroredMap_old(
+    makeErroredMap(
         cam_ang :: Sl.CameraAngles, 
         telescope_angles,
         signal :: Healpix.HealpixMap,

--- a/src/PRMaps.jl
+++ b/src/PRMaps.jl
@@ -2,9 +2,9 @@ module PRMaps
 
 import Stripeline as Sl
 using Healpix, Plots
+
 export Setup
-export makeIdealMap, makeErroredMap, makeMapPlots, makeErroredMap_old
-export getPixelIndex
+export makeIdealMap, makeErroredMap, plotErrorMap
 
 Base.@kwdef struct Setup
     τ_s :: Float64 = 0.0
@@ -118,6 +118,25 @@ function makeIdealMap(
 
     map.pixels = map.pixels ./ hits
     map
+end
+
+function plotErrorMap(
+    cam_ang, 
+    telescope_ang, 
+    signal :: HealpixMap, 
+    setup :: Setup
+    )
+    
+    ideal_map = makeIdealMap(cam_ang, signal, setup)
+    errored_map = makeErroredMap(cam_ang, telescope_ang, signal, setup)
+    result_map = ideal_map - errored_map
+
+    map = plot(result_map)
+    hist = histogram(result_map[isfinite.(result_map)])
+    hist_abs = histogram(abs.(result_map[isfinite.(result_map)]))
+
+    plot(map, hist, hist_abs, layout = (1,3), size = (1500,500))
+
 end
 
 end # module PrmMaps

--- a/src/PRMaps.jl
+++ b/src/PRMaps.jl
@@ -12,9 +12,9 @@ Base.@kwdef struct Setup
     NSIDE :: Int32 = 0
 end
 
-function add2pixel!(map, sky_value, pixel_idx, pixel_hits)
+function add2pixel!(map, sky_value, pixel_idx, hits_map)
     map.pixels[pixel_idx] += sky_value
-    pixel_hits[pixel_idx] += 1
+    hits_map.pixels[pixel_idx] += 1
 end
 
 """
@@ -60,7 +60,7 @@ function fillMap!(
     telescope_ang :: Sl.TelescopeAngles,
     signal :: HealpixMap,
     setup :: Setup,
-    hits :: Array{Int32},
+    hits :: HealpixMap,
     )
     
     pixbuf = Array{Int}(undef, 4)
@@ -115,7 +115,7 @@ function makeErroredMap(
     )
 
     map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
-    hits = zeros(Int32, 12*setup.NSIDE*setup.NSIDE)
+    hits = HealpixMap{Int32, RingOrder}(setup.NSIDE)#zeros(Int32, 12*setup.NSIDE*setup.NSIDE)
     wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, setup.τ_s*60.))
 
     fillMap!(wheelfunction, map, cam_ang, telescope_ang, signal, setup, hits)

--- a/src/PRMaps.jl
+++ b/src/PRMaps.jl
@@ -116,7 +116,7 @@ function makeIdealMap(
 
     fillIdealMap!(wheelfunction, map, cam_ang, signal, setup, hits)
 
-    map.pixels = map.pixels ./ hits
+    map.pixels = map.pixels ./ hits.pixels
     map
 end
 

--- a/src/PRMaps.jl
+++ b/src/PRMaps.jl
@@ -17,82 +17,6 @@ function add2pixel!(map, sky_value, pixel_idx, pixel_hits)
     pixel_hits[pixel_idx] += 1
 end
 
-#= function makeErroredMap(
-    cam_ang,
-    telescope_ang,
-    signal,
-    setup
-    )
-
-    map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
-    hits = zeros(Int32, 1, 12*setup.NSIDE*setup.NSIDE)
-
-    for t in setup.times
-
-        (dirs_ideal, _) = Sl.genpointings(cam_ang, t) do time
-            return (0.0, deg2rad(20.0), Sl.timetorotang(time, setup.τ_s*60.))
-        end  
-        pixel_index_ideal = ang2pix(signal, dirs_ideal[1], dirs_ideal[2])
-        
-        (dirs, _) = Sl.genpointings(cam_ang, t; telescope_ang = telescope_ang) do time
-            return (0.0, deg2rad(20.0), Sl.timetorotang(time, setup.τ_s*60.))
-        end  
-
-        sky_value = Healpix.interpolate(signal, dirs[1], dirs[2])
-
-        tod2map!(map, sky_value, pixel_index_ideal, hits)
-
-    end
-    
-    map
-end =#
-
-function fillMap!(
-    map :: HealpixMap,
-    wheelfunction,
-    cam_ang :: Sl.CameraAngles,
-    telescope_ang :: Sl.TelescopeAngles,
-    signal :: HealpixMap,
-    setup :: Setup,
-    hits :: Array{Int32},
-    dirs :: Array{Float64},
-    psi :: Array{Float64},
-    )
-    pixbuf = Array{Int}(undef, 4)
-    weightbuf = Array{Float64}(undef, 4)
-    for t in setup.times
-        
-        Sl.genpointings!(wheelfunction, cam_ang, t, dirs, psi)
-        pixel_index_ideal = ang2pix(signal, dirs[1], dirs[2])
-        
-        Sl.genpointings!(wheelfunction, cam_ang, t, dirs, psi; telescope_ang = telescope_ang)
-
-        sky_value = Healpix.interpolate(signal, dirs[1], dirs[2], pixbuf, weightbuf)
-
-        add2pixel!(map, sky_value, pixel_index_ideal, hits)
-
-    end
-end
-
-function makeErroredMap(
-    cam_ang :: Sl.CameraAngles,
-    telescope_ang :: Sl.TelescopeAngles,
-    signal :: HealpixMap,
-    setup :: Setup
-    )
-
-    map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
-    hits = zeros(Int32, 12*setup.NSIDE*setup.NSIDE)
-    dirs = Array{Float64}(undef, 1, 2)
-    psi = Array{Float64}(undef, 1)
-    wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, setup.τ_s*60.))
-
-    fillMap!(map, wheelfunction, cam_ang, telescope_ang, signal, setup, hits, dirs, psi)
-
-    map.pixels = map.pixels ./ hits
-    map
-end
-
 """
     getPixelIndex(
         cam_ang :: Stripeline.CameraAngles,
@@ -108,13 +32,10 @@ This function return the indeces of the pixel seeing by the telescope given:
     - `signal :: Healpix.HealpixMap` : the input map that the telescope is going to observe;
     - `setup :: PRMaps.Setup` : encoding the information about period of observation and resolution.
 
-This function is provided in two flavours. The second one accepting `telescope_ang = nothing` is used to
-simulate the ideal case.
-
 """
-#= function getPixelIndex(
+function getPixelIndex(
     cam_ang :: Sl.CameraAngles,
-    telescope_ang :: Sl.TelescopeAngles,
+    telescope_ang :: Union{Nothing, Sl.TelescopeAngles},
     signal :: HealpixMap,
     setup :: Setup
     )
@@ -127,83 +48,120 @@ simulate the ideal case.
         colat, long = dirs[i,:]
         pixel_index[i] = ang2pix(signal, colat, long)
     end
-    pixel_index, dirs
+    pixel_index
 end
 
-function getPixelIndex(
+function fillMap!(
+    map :: HealpixMap,
+    wheelfunction,
     cam_ang :: Sl.CameraAngles,
-    telescope_ang :: Nothing,
+    telescope_ang :: Sl.TelescopeAngles,
+    signal :: HealpixMap,
+    setup :: Setup,
+    hits :: Array{Int32},
+    )
+    
+    pixbuf = Array{Int}(undef, 4)
+    weightbuf = Array{Float64}(undef, 4)
+    dirs = Array{Float64}(undef, 1, 2)
+    psi = Array{Float64}(undef, 1)
+    
+    for t in setup.times
+        
+        Sl.genpointings!(wheelfunction, cam_ang, t, dirs, psi)
+        pixel_index_ideal = ang2pix(signal, dirs[1], dirs[2])
+        
+        Sl.genpointings!(wheelfunction, cam_ang, t, dirs, psi; telescope_ang = telescope_ang)
+
+        sky_value = Healpix.interpolate(signal, dirs[1], dirs[2], pixbuf, weightbuf)
+
+        add2pixel!(map, sky_value, pixel_index_ideal, hits)
+
+    end
+end
+
+function fillTOD!(
+    tod,
+    wheelfunction,
+    cam_ang :: Sl.CameraAngles,
+    telescope_ang :: Sl.TelescopeAngles,
+    signal :: HealpixMap,
+    setup :: Setup,
+    )
+
+    pixbuf = Array{Int}(undef, 4)
+    weightbuf = Array{Float64}(undef, 4)
+    dirs = Array{Float64}(undef, 1, 2)
+    psi = Array{Float64}(undef, 1)
+    
+    for (indx, t) in enumerate(setup.times)
+        
+        Sl.genpointings!(wheelfunction, cam_ang, t, dirs, psi; telescope_ang = telescope_ang)
+
+        sky_value = Healpix.interpolate(signal, dirs[1], dirs[2], pixbuf, weightbuf)
+
+        tod[indx] = sky_value
+
+    end
+end
+
+function makeErroredMap(
+    cam_ang :: Sl.CameraAngles,
+    telescope_ang :: Sl.TelescopeAngles,
     signal :: HealpixMap,
     setup :: Setup
     )
-    
-    pixel_index = Array{Int}(undef, length(setup.times))
-    (dirs, _) = Sl.genpointings(cam_ang, setup.times) do time_s
-        return (0.0, deg2rad(20.0), Sl.timetorotang(time_s, setup.τ_s*60.))
-    end
-    for i in 1:length(setup.times)
-        colat, long = dirs[i,:]
-        pixel_index[i] = ang2pix(signal, colat, long)
-    end
-    pixel_index, dirs
+
+    map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
+    hits = zeros(Int32, 12*setup.NSIDE*setup.NSIDE)
+    wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, setup.τ_s*60.))
+
+    fillMap!(map, wheelfunction, cam_ang, telescope_ang, signal, setup, hits)
+
+    map.pixels = map.pixels ./ hits
+    map
 end
- =#
+
+
 """
-    makeErroredMap(
+    makeErroredMap_old(
         cam_ang :: Sl.CameraAngles, 
         telescope_angles,
         signal :: Healpix.HealpixMap,
-        pixel_index_ideal :: Array{Int, 1},
         setup :: Setup
     )
 
-Generate a collection of Healpix maps using a telescope model that takes into account of
+Generate a Healpix map using a telescope model that takes into account of
 the non idealities to generate the pointing direction. The observed values instead are
 calculated taking into account the ideal pointing directions. The result is a map affected
 by an error due to the non idealities of the system.
 
-This function comes into two flavours: telescope_ang could be both a single Sl.TelescopeAngles
-or a collection of them returning an Array of HealpixMap.
-
 """
-#= function makeErroredMap_old(
-    cam_ang :: Sl.CameraAngles, 
+function makeErroredMap_old(
+    cam_ang :: Sl.CameraAngles,
     telescope_ang :: Sl.TelescopeAngles,
-    signal :: Healpix.HealpixMap,
-    setup::Setup
-    )
-    
-    pixel_index_ideal, _ = getPixelIndex(cam_ang, nothing, signal, setup)
-    _, dirs = getPixelIndex(cam_ang, telescope_ang, signal, setup)
-    
-    # Return the tod containing the observed values associated with the directions with error
-    pixbuf = Array{Int}(undef, 4)
-    weightbuf = Array{Float64}(undef, 4)
-    for (θ, ϕ) in dirs
-        sky_tod = Healpix.interpolate(signal, θ, ϕ, pixbuf, weightbuf)
-    end
+    signal :: HealpixMap,
+    setup :: Setup   
+)
+    ideal_indx = getPixelIndex(cam_ang, nothing, signal, setup)
+
+    tod = Array{Float64}(undef, length(setup.times))
+
+    wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, setup.τ_s*60.))
+
+    fillTOD!(tod, wheelfunction, cam_ang, telescope_ang, signal, setup)
+
     # Create a map using the values (with error) associated to the pixel that we belive we observe
-    map_values = Sl.tod2map_mpi(pixel_index_ideal, sky_tod, 12*(setup.NSIDE^2))
+    map_values = Sl.tod2map_mpi(ideal_indx, tod, 12*(setup.NSIDE^2))
 
     map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
     map.pixels = map_values
     
     map
-end =#
 
-#= function makeErroredMap(
-    cam_ang :: Sl.CameraAngles, 
-    telescope_angles :: Vector{Sl.TelescopeAngles},
-    signal :: Healpix.HealpixMap,
-    pixel_index_ideal :: Array{Int, 1},
-    setup :: Setup
-    )
+end
 
-    [makeErroredMap(cam_ang, tel, signal, pixel_index_ideal, setup) for tel in telescope_angles]
-    
-end =#
 
-# Flavour to make ideal maps
 function makeIdealMap(
     cam_ang :: Sl.CameraAngles, 
     telescope_ang :: Nothing,
@@ -222,32 +180,5 @@ function makeIdealMap(
 
     map
 end
-
-#= function makeMapPlots(
-    cam_ang :: Sl.CameraAngles, 
-    telescope_angles :: Sl.TelescopeAngles,
-    signal :: Healpix.HealpixMap,
-    map_ideal :: Healpix.HealpixMap,
-    setup::Setup
-    )
-    
-    pixel_index_ideal = getPixelIndex(cam_ang, nothing, signal, setup)
-    map = makeErroredMap(cam_ang, telescope_angles, signal, pixel_index_ideal, setup)
-    result = (map-map_ideal)/map_ideal
-    plot(result)
-end
-
-function makeMapPlots(
-    cam_ang :: Sl.CameraAngles, 
-    telescope_angles :: Vector{Sl.TelescopeAngles},
-    signal :: Healpix.HealpixMap,
-    map_ideal :: Healpix.HealpixMap,
-    setup::Setup
-    )
-    
-    pixel_index_ideal = getPixelIndex(cam_ang, nothing, signal, setup)
-    maps = makeErroredMap(cam_ang, telescope_angles, signal, pixel_index_ideal, setup)
-    [plot((map-map_ideal)/map_ideal) for map in maps]
-end =#
 
 end # module PrmMaps


### PR DESCRIPTION
The first version of the code saves two vectors containing the pixel indexes for the ideal map and the map with errors.
This new version tries to update step by step the final map without save the indexes.

- [x] Add a function `makeErroredMap` that create the map step by step.
- [x] Add a flavor of `makeErroredMap` that create the map saving the tod vector.
- [x] Benchmark the two function and choose the better one.
- [x] Create a CHANGELOG