### PR TITLE
Menage Healpix.PolarizedHealpixMap

### DIFF
--- a/src/pointingMaps.jl
+++ b/src/pointingMaps.jl
@@ -188,3 +188,52 @@ function makeErroredMapIQU(
 
     return (map, hits)
 end
+
+function fill_IQU_IdealMaps!(
+    wheelfunction,
+    map :: PolarizedHealpixMap,
+    cam_ang :: Sl.CameraAngles,
+    signal :: PolarizedHealpixMap,
+    setup :: Setup,
+    hits :: PolarizedHealpixMap,
+    )
+    
+    pixbuf = Array{Int}(undef, 4)
+    weightbuf = Array{Float64}(undef, 4)
+    dirs = Array{Float64}(undef, 1, 2)
+    psi = Array{Float64}(undef, 1)
+    
+    for t in setup.times
+        
+        Sl.genpointings!(wheelfunction, cam_ang, t, dirs, psi)
+        pixel_index_ideal = ang2pix(signal, dirs[1], dirs[2])
+        
+        i_value = Healpix.interpolate(signal.i, dirs[1], dirs[2], pixbuf, weightbuf)
+        q_value = Healpix.interpolate(signal.q, dirs[1], dirs[2], pixbuf, weightbuf)
+        u_value = Healpix.interpolate(signal.u, dirs[1], dirs[2], pixbuf, weightbuf)
+
+        add2pixel!(map.i, i_value, pixel_index_ideal, hits.i)
+        add2pixel!(map.q, q_value, pixel_index_ideal, hits.q)
+        add2pixel!(map.u, u_value, pixel_index_ideal, hits.u)
+
+    end
+    return nothing
+end
+
+function makeIdealMapIQU(
+    cam_ang :: Sl.CameraAngles,
+    signal :: PolarizedHealpixMap,
+    setup :: PRMaps.Setup
+)
+    map = PolarizedHealpixMap{Float64, RingOrder}(setup.NSIDE)
+    hits = PolarizedHealpixMap{Int32, RingOrder}(setup.NSIDE)
+    wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, setup.τ_s*60.))
+    
+    fill_IQU_IdealMaps!(wheelfunction, map, cam_ang, signal, setup, hits)
+
+    map.i.pixels = map.i.pixels ./ hits.i.pixels
+    map.q.pixels = map.q.pixels ./ hits.q.pixels
+    map.u.pixels = map.u.pixels ./ hits.u.pixels
+
+    return (map, hits)
+end

--- a/src/pointingMaps.jl
+++ b/src/pointingMaps.jl
@@ -89,6 +89,9 @@ the non idealities to generate the pointing direction. The observed values inste
 calculated taking into account the ideal pointing directions. 
 The result is a map affected by an error due to the non idealities of the system.
 
+Return a tuple `(map, hits)::(Healpix, Healpix)`:
+- `map` contains the obserbed values of signal;
+- `hits` contains for every pixels the count of how many times the pixel is seen.
 """
 function makeErroredMap(
     cam_ang :: Sl.CameraAngles,
@@ -115,6 +118,10 @@ end
     )
 
 Generate a Healpix map using an ideal telescope model.
+
+Return a tuple `(map, hits)::(Healpix, Healpix)`:
+- `map` contains the obserbed values of signal;
+- `hits` contains for every pixels the count of how many times the pixel is seen.
 """
 function makeIdealMap(
     cam_ang :: Sl.CameraAngles,
@@ -170,6 +177,24 @@ function fill_IQU_ErroredMaps!(
     return nothing
 end
 
+
+"""
+    makeErroredMap(
+        cam_ang :: Sl.CameraAngles, 
+        telescope_angles :: Sl.TelescopeAngles,
+        signal :: Healpix.PolarizedHealpixMap,
+        setup :: Setup
+    )
+
+Generate a PolarizedHealpix map (I,Q,U) using a telescope model that takes into account
+the non idealities to generate the pointing direction. The observed values instead are
+calculated taking into account the ideal pointing directions. 
+The result is a map affected by an error due to the non idealities of the system.
+
+Return a tuple `(map, hits)::(PolarizedHealpix, PolarizedHealpix)`:
+- `map` contains the obserbed values of signal;
+- `hits` contains for every pixels the count of how many times the pixel is seen.
+"""
 function makeErroredMapIQU(
     cam_ang :: Sl.CameraAngles,
     tel_ang :: Sl.TelescopeAngles,
@@ -220,6 +245,20 @@ function fill_IQU_IdealMaps!(
     return nothing
 end
 
+
+"""
+    makeIdealMap(
+        cam_ang :: Sl.CameraAngles, 
+        signal :: Healpix.PolarizedHealpixMap,
+        setup :: Setup
+    )
+
+Generate a PolarizedHealpix map (I,Q,U) using an ideal telescope model.
+
+Return a tuple `(map, hits)::(PolarizedHealpix, PolarizedHealpix)`:
+- `map` contains the obserbed values of signal;
+- `hits` contains for every pixels the count of how many times the pixel is seen.
+"""
 function makeIdealMapIQU(
     cam_ang :: Sl.CameraAngles,
     signal :: PolarizedHealpixMap,

--- a/src/pointingMaps.jl
+++ b/src/pointingMaps.jl
@@ -3,6 +3,7 @@ using Healpix
 
 export Setup
 export makeIdealMap, makeErroredMap
+export makeErroredMapIQU, makeIdealMapIQU
 export add2pixel!
 
 Base.@kwdef struct Setup
@@ -128,5 +129,62 @@ function makeIdealMap(
     fillIdealMap!(wheelfunction, map, cam_ang, signal, setup, hits)
 
     map.pixels = map.pixels ./ hits.pixels
+    return (map, hits)
+end
+
+# ---------------------------------------------------------------------------------
+# ---------------------------------------------------------------------------------
+# ---------------------------------------------------------------------------------
+
+function fill_IQU_ErroredMaps!(
+    wheelfunction,
+    map :: PolarizedHealpixMap,
+    cam_ang :: Sl.CameraAngles,
+    telescope_ang :: Sl.TelescopeAngles,
+    signal :: PolarizedHealpixMap,
+    setup :: Setup,
+    hits :: PolarizedHealpixMap,
+    )
+    
+    pixbuf = Array{Int}(undef, 4)
+    weightbuf = Array{Float64}(undef, 4)
+    dirs = Array{Float64}(undef, 1, 2)
+    psi = Array{Float64}(undef, 1)
+    
+    for t in setup.times
+        
+        Sl.genpointings!(wheelfunction, cam_ang, t, dirs, psi)
+        pixel_index_ideal = ang2pix(signal, dirs[1], dirs[2])
+        
+        Sl.genpointings!(wheelfunction, cam_ang, t, dirs, psi; telescope_ang = telescope_ang)
+
+        i_value = Healpix.interpolate(signal.i, dirs[1], dirs[2], pixbuf, weightbuf)
+        q_value = Healpix.interpolate(signal.q, dirs[1], dirs[2], pixbuf, weightbuf)
+        u_value = Healpix.interpolate(signal.u, dirs[1], dirs[2], pixbuf, weightbuf)
+
+        add2pixel!(map.i, i_value, pixel_index_ideal, hits.i)
+        add2pixel!(map.q, q_value, pixel_index_ideal, hits.q)
+        add2pixel!(map.u, u_value, pixel_index_ideal, hits.u)
+
+    end
+    return nothing
+end
+
+function makeErroredMapIQU(
+    cam_ang :: Sl.CameraAngles,
+    tel_ang :: Sl.TelescopeAngles,
+    signal :: PolarizedHealpixMap,
+    setup :: PRMaps.Setup
+)
+    map = PolarizedHealpixMap{Float64, RingOrder}(setup.NSIDE)
+    hits = PolarizedHealpixMap{Int32, RingOrder}(setup.NSIDE)
+    wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, setup.τ_s*60.))
+    
+    fill_IQU_ErroredMaps!(wheelfunction, map, cam_ang, tel_ang, signal, setup, hits)
+
+    map.i.pixels = map.i.pixels ./ hits.i.pixels
+    map.q.pixels = map.q.pixels ./ hits.q.pixels
+    map.u.pixels = map.u.pixels ./ hits.u.pixels
+
     return (map, hits)
 end

--- a/src/polarizationMaps.jl
+++ b/src/polarizationMaps.jl
@@ -109,11 +109,10 @@ function makePolDegreeMap(
     signal::PolarizedHealpixMap,
     setup::Setup
 )
-    (q_map, u_map) = makePolMap(cam_ang, tel_ang, signal, setup)
-    i_map, _ = makeErroredMap(cam_ang, tel_ang, signal.i, setup)
+    signal_map, _ = makeErroredMapIQU(cam_ang, tel_ang, signal, setup)
     p_map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
     
-    polDegreeMap!(p_map, i_map, q_map, u_map)
+    polDegreeMap!(p_map, signal_map.i, signal_map.q, signal_map.u)
 
     return p_map
 end
@@ -123,11 +122,10 @@ function makePolDegreeMap(
     signal::PolarizedHealpixMap,
     setup::Setup
 )
-    (q_map, u_map) = makePolMap(cam_ang, signal, setup)
-    i_map, _ = makeIdealMap(cam_ang, signal.i, setup)
+    signal_map, _ = makeIdealMapIQU(cam_ang, signal, setup)
     p_map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
-    
-    polDegreeMap!(p_map, i_map, q_map, u_map)
+
+    polDegreeMap!(p_map, signal_map.i, signal_map.q, signal_map.u)
 
     return p_map
 end
@@ -206,10 +204,10 @@ function makePolAngMap(
     setup :: Setup
     )
 
-    (q_map, u_map) = makePolMap(cam_ang, tel_ang, signal, setup)
+    signal_map, _ = makeErroredMapIQU(cam_ang, tel_ang, signal, setup)
     p_map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
     
-    polAngleMap!(p_map, q_map, u_map)
+    polAngleMap!(p_map, signal_map.q, signal_map.u)
 
     return p_map
 end
@@ -220,10 +218,10 @@ function makePolAngMap(
     setup :: Setup
     )
 
-    (q_map, u_map) = makePolMap(cam_ang, signal, setup)
+    signal_map, _ = makeIdealMapIQU(cam_ang, signal, setup)
     p_map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
     
-    polAngleMap!(p_map, q_map, u_map)
+    polAngleMap!(p_map, signal_map.q, signal_map.u)
 
     return p_map
 end

--- a/src/polarizationMaps.jl
+++ b/src/polarizationMaps.jl
@@ -6,66 +6,6 @@ export makePolMap, makePolDegreeMap, makePolAngMap
 export polAngleMap!, polDegreeMap!
 export differenceAngMaps
 
-function makePolMap(
-    cam_ang::CameraAngles,
-    signal::PolarizedHealpixMap,
-    setup::Setup
-)
-    q_map, _ = makeIdealMap(cam_ang, signal.q, setup)
-    u_map, _ = makeIdealMap(cam_ang, signal.u, setup)
-    
-    return (q_map, u_map)
-
-end
-
-function makePolMap(
-    cam_ang::CameraAngles,
-    tel_ang::TelescopeAngles,
-    signal::PolarizedHealpixMap,
-    setup::Setup
-)
-    q_map, _ = makeErroredMap(cam_ang, tel_ang, signal.q, setup)
-    u_map, _ = makeErroredMap(cam_ang, tel_ang, signal.u, setup)
-
-    return (q_map, u_map)
-
-end
-
-"""
-    makePolMap(
-        cam_ang::Stripeline.CameraAngles,
-        signal::Healpix.PolarizedHealpixMap,
-        setup::PRMaps.Setup
-    )
-
-    makePolMap(
-        cam_ang::Stripeline.CameraAngles,
-        tel_ang::Stripeline.TelescopeAngles,
-        signal::Healpix.PolarizedHealpixMap,
-        setup::PRMaps.Setup
-    )
-
-Return the Q and U maps of the sky observed by a telescope 
-whose camera point towards a direction encoded by
-the CameraAngles struct.
-
-The second flavour, with a TelescopeAngles as input, produce a
-map affected by an error. See [makeErroredMap](@ref)
-
-Input:
-- `cam_ang :: CameraAngles` encoding the pointing direction of the detector;
-- `tel_ang::Stripeline.TelescopeAngles` encoding the non idealities of the telescope;
-- `signal::Healpix.PolarizedHealpixMap` the signal (Q,U,I) that the telescope are going to observe;
-- `setup::PRMaps.Setup` see [Setup](@ref).
-
-Output:
-- `(q_map, u_map)` each of them is an HealpixMap containing respectively the Q and U components observed by the telescope.
-"""
-makePolMap
-
-#--------------------------------------------------------------------------------
-#--------------------------------------------------------------------------------
-
 """
     function polDegreeMap!(
         p_map::HealpixMap,

--- a/src/polarizationMaps.jl
+++ b/src/polarizationMaps.jl
@@ -2,7 +2,7 @@ using Stripeline
 using Healpix
 using PRMaps
 
-export makePolMap, makePolDegreeMap, makePolAngMap
+export makePolDegreeMap, makePolAngMap
 export polAngleMap!, polDegreeMap!
 export differenceAngMaps
 


### PR DESCRIPTION
Aim of this PR is to modify PRMaps so that it will calculate directly a PolarizedHealpixMap (containing I,Q,U components). In this way to create a polarization degree map or an angle of polarization map the pointings are calculated only once.