### PR TITLE
Change PRMaps.Setup behavior

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,9 +3,8 @@ name: Documentation
 on:
   push:
     branches:
-      - master # update to match your development branch (master, main, dev, trunk, ...)
+      - master
     tags: '*'
-  pull_request:
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # HEAD
 
+# Version 0.2.0
+- Changed PRMaps.Setup behavior [#6](https://github.com/teob97/PRMaps.jl/pull/6)
+
 # Version 0.1.0
 - Added `makePolDegreeMap`, `makePolAngMap` and `differenceAngMaps`.
 - Added `makeErroredMap` and `makeIdealMap` to generate sky maps observed by a given telescope setup.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PRMaps"
 uuid = "fd40e84c-20b6-49bc-bda0-919ee04f3f0e"
 authors = ["Baratto Matteo <teo.baratto.97@gmail.com>"]
-version = "0.1.0"
+version = "0.2.0"
 
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"

--- a/script_python/signal_generator.py
+++ b/script_python/signal_generator.py
@@ -4,14 +4,14 @@ import healpy as hp
 import numpy as np
 import matplotlib.pyplot as plt
 # Create a map object specifing resolution and model 
-sky = pysm3.Sky(nside=512, preset_strings=["s1"])
+sky = pysm3.Sky(nside=512, preset_strings=["s0"])
 # Restituisce un vettore numpy (3,npixel) con i parametri di stokes [I,Q,U] espressi in microKelvin_RJ (Rayleigh-Jeans)
 map_40GHz = sky.get_emission(40 * u.GHz)
-map_40GHz = map_40GHz.to(u.uK_CMB, equivalencies=u.cmb_equivalencies(40*u.GHz))
+#map_40GHz = map_40GHz.to(u.uK_CMB, equivalencies=u.cmb_equivalencies(40*u.GHz))
 # Convert from celestial coordinates to equatorial
 map_40GHz_equat = pysm3.apply_smoothing_and_coord_transform(map_40GHz, rot=hp.Rotator(coord=("G", "C")))
 # Save into .fits file
-hp.fitsfunc.write_map("../input_maps/map_40GHz.fits", map_40GHz_equat, coord = "C", overwrite=True)
+hp.fitsfunc.write_map("input_maps/map_40GHz.fits", map_40GHz_equat, coord = "C", overwrite=True)
 # Visualize temperature map
 # hp.mollview(map_40GHz_equat[0], min=0, max=1e2, title="I map", unit=map_40GHz_equat.unit)
 # Polarization map

--- a/src/pointingMaps.jl
+++ b/src/pointingMaps.jl
@@ -46,7 +46,6 @@ Arguments:
 Base.@kwdef struct Setup
     τ_s :: Float64 = 0.0
     times :: StepRangeLen = 0:0:0
-    NSIDE :: Int32 = 0
 end
 
 function add2pixel!(map, sky_value, pixel_idx, hits_map)
@@ -137,8 +136,8 @@ function makeErroredMap(
     setup :: Setup
     )
 
-    map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
-    hits = HealpixMap{Int32, RingOrder}(setup.NSIDE)
+    map = HealpixMap{Float64, RingOrder}(signal.resolution.nside)
+    hits = HealpixMap{Int32, RingOrder}(signal.resolution.nside)
     wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, setup.τ_s*60.))
 
     fillMap!(wheelfunction, map, cam_ang, telescope_ang, signal, setup, hits)
@@ -166,8 +165,8 @@ function makeIdealMap(
     setup :: Setup
     )
 
-    map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
-    hits = HealpixMap{Int32, RingOrder}(setup.NSIDE)
+    map = HealpixMap{Float64, RingOrder}(signal.resolution.nside)
+    hits = HealpixMap{Int32, RingOrder}(signal.resolution.nside)
     wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, setup.τ_s*60.))
 
     fillIdealMap!(wheelfunction, map, cam_ang, signal, setup, hits)
@@ -238,8 +237,8 @@ function makeErroredMapIQU(
     signal :: PolarizedHealpixMap,
     setup :: PRMaps.Setup
 )
-    map = PolarizedHealpixMap{Float64, RingOrder}(setup.NSIDE)
-    hits = PolarizedHealpixMap{Int32, RingOrder}(setup.NSIDE)
+    map = PolarizedHealpixMap{Float64, RingOrder}(signal.i.resolution.nside)
+    hits = PolarizedHealpixMap{Int32, RingOrder}(signal.i.resolution.nside)
     wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, setup.τ_s*60.))
     
     fill_IQU_ErroredMaps!(wheelfunction, map, cam_ang, tel_ang, signal, setup, hits)
@@ -301,8 +300,8 @@ function makeIdealMapIQU(
     signal :: PolarizedHealpixMap,
     setup :: PRMaps.Setup
 )
-    map = PolarizedHealpixMap{Float64, RingOrder}(setup.NSIDE)
-    hits = PolarizedHealpixMap{Int32, RingOrder}(setup.NSIDE)
+    map = PolarizedHealpixMap{Float64, RingOrder}(signal.i.resolution.nside)
+    hits = PolarizedHealpixMap{Int32, RingOrder}(signal.i.resolution.nside)
     wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, setup.τ_s*60.))
     
     fill_IQU_IdealMaps!(wheelfunction, map, cam_ang, signal, setup, hits)

--- a/src/pointingMaps.jl
+++ b/src/pointingMaps.jl
@@ -32,7 +32,6 @@ export add2pixel!
     Setup(
         τ_s :: Float64,
         times :: StepRangeLen,
-        NSIDE :: Int32
     )
 
 Struct containing some useful data.
@@ -44,8 +43,8 @@ Arguments:
 - `NSIDE` : map resolution
 """
 Base.@kwdef struct Setup
-    τ_s :: Float64 = 0.0
-    times :: StepRangeLen = 0:0:0
+    sampling_freq_Hz :: Float64 = 0.0
+    total_time_s :: Float64 = 0.0
 end
 
 function add2pixel!(map, sky_value, pixel_idx, hits_map)
@@ -68,8 +67,9 @@ function fillMap!(
     weightbuf = Array{Float64}(undef, 4)
     dirs = Array{Float64}(undef, 1, 2)
     psi = Array{Float64}(undef, 1)
-    
-    for t in setup.times
+    times = 0 : 1.0/setup.sampling_freq_Hz : setup.total_time_s
+
+    for t in times
         
         Sl.genpointings!(wheelfunction, cam_ang, t, dirs, psi)
         pixel_index_ideal = ang2pix(signal, dirs[1], dirs[2])
@@ -97,8 +97,9 @@ function fillIdealMap!(
     weightbuf = Array{Float64}(undef, 4)
     dirs = Array{Float64}(undef, 1, 2)
     psi = Array{Float64}(undef, 1)
+    times = 0 : 1.0/setup.sampling_freq_Hz : setup.total_time_s
     
-    for t in setup.times
+    for t in times
         
         Sl.genpointings!(wheelfunction, cam_ang, t, dirs, psi)
         
@@ -138,7 +139,7 @@ function makeErroredMap(
 
     map = HealpixMap{Float64, RingOrder}(signal.resolution.nside)
     hits = HealpixMap{Int32, RingOrder}(signal.resolution.nside)
-    wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, setup.τ_s*60.))
+    wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, 1.0))
 
     fillMap!(wheelfunction, map, cam_ang, telescope_ang, signal, setup, hits)
 
@@ -167,7 +168,7 @@ function makeIdealMap(
 
     map = HealpixMap{Float64, RingOrder}(signal.resolution.nside)
     hits = HealpixMap{Int32, RingOrder}(signal.resolution.nside)
-    wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, setup.τ_s*60.))
+    wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, 1.0))
 
     fillIdealMap!(wheelfunction, map, cam_ang, signal, setup, hits)
 
@@ -193,8 +194,9 @@ function fill_IQU_ErroredMaps!(
     weightbuf = Array{Float64}(undef, 4)
     dirs = Array{Float64}(undef, 1, 2)
     psi = Array{Float64}(undef, 1)
+    times = 0 : 1.0/setup.sampling_freq_Hz : setup.total_time_s
     
-    for t in setup.times
+    for t in times
         
         Sl.genpointings!(wheelfunction, cam_ang, t, dirs, psi)
         pixel_index_ideal = ang2pix(signal, dirs[1], dirs[2])
@@ -239,7 +241,7 @@ function makeErroredMapIQU(
 )
     map = PolarizedHealpixMap{Float64, RingOrder}(signal.i.resolution.nside)
     hits = PolarizedHealpixMap{Int32, RingOrder}(signal.i.resolution.nside)
-    wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, setup.τ_s*60.))
+    wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, 1.0))
     
     fill_IQU_ErroredMaps!(wheelfunction, map, cam_ang, tel_ang, signal, setup, hits)
 
@@ -263,8 +265,9 @@ function fill_IQU_IdealMaps!(
     weightbuf = Array{Float64}(undef, 4)
     dirs = Array{Float64}(undef, 1, 2)
     psi = Array{Float64}(undef, 1)
+    times = 0 : 1.0/setup.sampling_freq_Hz : setup.total_time_s
     
-    for t in setup.times
+    for t in times
         
         Sl.genpointings!(wheelfunction, cam_ang, t, dirs, psi)
         pixel_index_ideal = ang2pix(signal, dirs[1], dirs[2])
@@ -302,7 +305,7 @@ function makeIdealMapIQU(
 )
     map = PolarizedHealpixMap{Float64, RingOrder}(signal.i.resolution.nside)
     hits = PolarizedHealpixMap{Int32, RingOrder}(signal.i.resolution.nside)
-    wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, setup.τ_s*60.))
+    wheelfunction = x -> (0.0, deg2rad(20.0), Sl.timetorotang(x, 1.0))
     
     fill_IQU_IdealMaps!(wheelfunction, map, cam_ang, signal, setup, hits)
 

--- a/src/pointingMaps.jl
+++ b/src/pointingMaps.jl
@@ -30,17 +30,11 @@ export add2pixel!
 
 """
     Setup(
-        τ_s :: Float64,
-        times :: StepRangeLen,
+        sampling_freq_Hz :: Float64,
+        total_time_s :: Float64    
     )
 
 Struct containing some useful data.
-
-Arguments:
-
-- `τ_s` : sampling time (defined as 1 / sampling_frequency)
-- `times` : time range (usually 0:τ_s:total_time)
-- `NSIDE` : map resolution
 """
 Base.@kwdef struct Setup
     sampling_freq_Hz :: Float64 = 0.0

--- a/src/polarizationMaps.jl
+++ b/src/polarizationMaps.jl
@@ -72,7 +72,7 @@ function makePolDegreeMap(
     setup::Setup
 )
     signal_map, _ = makeErroredMapIQU(cam_ang, tel_ang, signal, setup)
-    p_map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
+    p_map = HealpixMap{Float64, RingOrder}(signal.i.resolution.nside)
     
     polDegreeMap!(p_map, signal_map.i, signal_map.q, signal_map.u)
 
@@ -85,7 +85,7 @@ function makePolDegreeMap(
     setup::Setup
 )
     signal_map, _ = makeIdealMapIQU(cam_ang, signal, setup)
-    p_map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
+    p_map = HealpixMap{Float64, RingOrder}(signal.i.resolution.nside)
 
     polDegreeMap!(p_map, signal_map.i, signal_map.q, signal_map.u)
 
@@ -167,7 +167,7 @@ function makePolAngMap(
     )
 
     signal_map, _ = makeErroredMapIQU(cam_ang, tel_ang, signal, setup)
-    p_map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
+    p_map = HealpixMap{Float64, RingOrder}(signal.i.resolution.nside)
     
     polAngleMap!(p_map, signal_map.q, signal_map.u)
 
@@ -181,7 +181,7 @@ function makePolAngMap(
     )
 
     signal_map, _ = makeIdealMapIQU(cam_ang, signal, setup)
-    p_map = HealpixMap{Float64, RingOrder}(setup.NSIDE)
+    p_map = HealpixMap{Float64, RingOrder}(signal.i.resolution.nside)
     
     polAngleMap!(p_map, signal_map.q, signal_map.u)
 


### PR DESCRIPTION
Setup struct contains the following informations:
- &tau;_s that is the sampling time ( 1 / sampling_frequency)
- the observation time range
- NSIDE

Aim of this PR is:
- remove NSIDE, it will be inferred from the signal map to avoid mismatch
- pass the sampling_frequency and the total time instead of the entire range